### PR TITLE
A0: Improve styled components debugging

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -76,7 +76,19 @@
         "singleReturnOnly": false
       }
     ],
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [{
+          "name": "styled-components",
+          "message": "Please import from styled-components/macro to enable dev tooling."
+        }],
+        "patterns": [
+          "!styled-components/macro"
+        ]
+      }
+    ]
   },
   "settings": {
     "import/resolver": {

--- a/babel-plugin-macros.config.js
+++ b/babel-plugin-macros.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  styledComponents: {
+    displayName: process.env.NODE_ENV !== 'production'
+  }
+}

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -30,7 +30,7 @@ import { UIProvider } from 'contexts/UI';
 import { ValidatorsProvider } from 'contexts/Validators';
 import { withProviders } from 'library/Hooks';
 import Router from 'Router';
-import { ThemeProvider } from 'styled-components';
+import { ThemeProvider } from 'styled-components/macro';
 import { EntryWrapper as Wrapper } from 'Wrappers';
 
 // `polkadot-dashboard-ui` theme classes are inserted here.

--- a/src/Wrappers.tsx
+++ b/src/Wrappers.tsx
@@ -9,7 +9,7 @@ import {
   SideMenuStickyThreshold,
 } from 'consts';
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   backgroundGradient,
   backgroundPrimary,

--- a/src/library/Account/Wrapper.ts
+++ b/src/library/Account/Wrapper.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderPrimary, borderSecondary, textSecondary } from 'theme';
 
 export const Wrapper = styled(motion.button)<any>`

--- a/src/library/ErrorBoundary/Wrapper.ts
+++ b/src/library/ErrorBoundary/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { textSecondary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/library/EstimatedTxFee/Wrapper.tsx
+++ b/src/library/EstimatedTxFee/Wrapper.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { textSecondary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/library/Filter/Wrappers.ts
+++ b/src/library/Filter/Wrappers.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   borderPrimary,
   buttonPrimaryBackground,

--- a/src/library/Form/AccountDropdown/Wrappers.ts
+++ b/src/library/Form/AccountDropdown/Wrappers.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   backgroundDropdown,
   borderPrimary,

--- a/src/library/Form/AccountSelect/Wrappers.ts
+++ b/src/library/Form/AccountSelect/Wrappers.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { backgroundToggle, borderPrimary, textPrimary } from 'theme';
 
 export const StyledDownshift = styled.div<any>`

--- a/src/library/Form/CreatePoolStatusBar/Wrapper.ts
+++ b/src/library/Form/CreatePoolStatusBar/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { backgroundLabel, networkColor, textSecondary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/library/Form/NominateStatusBar/Wrapper.ts
+++ b/src/library/Form/NominateStatusBar/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { backgroundLabel, networkColor, textSecondary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/library/Form/Warning/Wrapper.ts
+++ b/src/library/Form/Warning/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { backgroundLabel } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/library/Form/Wrappers.ts
+++ b/src/library/Form/Wrappers.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderPrimary, textSecondary } from 'theme';
 
 export const Spacer = styled.div`

--- a/src/library/GenerateNominations/Wrappers.ts
+++ b/src/library/GenerateNominations/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SectionFullWidthThreshold } from 'consts';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const GenerateOptionsWrapper = styled.div`
   width: 100%;

--- a/src/library/Graphs/Wrappers.ts
+++ b/src/library/Graphs/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SideMenuStickyThreshold } from 'consts';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   backgroundSecondary,
   borderPrimary,

--- a/src/library/Headers/Spinner.tsx
+++ b/src/library/Headers/Spinner.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { backgroundPrimary } from 'theme';
 
 const StyledSpinner = styled.div`

--- a/src/library/Headers/Wrappers.ts
+++ b/src/library/Headers/Wrappers.ts
@@ -6,7 +6,7 @@ import {
   SideMenuStickyThreshold,
 } from 'consts';
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   borderPrimary,
   buttonSecondaryBackground,

--- a/src/library/Help/Wrappers.ts
+++ b/src/library/Help/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   helpButton,
   modalOverlayBackground,

--- a/src/library/Identicon/index.tsx
+++ b/src/library/Identicon/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Identicon as IdenticonDefault } from '@polkadot/react-identicon';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { backgroundIdenticon } from 'theme';
 import { IdenticonProps } from './types';
 

--- a/src/library/List/index.ts
+++ b/src/library/List/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderPrimary, networkColor, textPrimary, textSecondary } from 'theme';
 import { ListProps, PaginationWrapperProps } from './types';
 

--- a/src/library/ListItem/Labels/Select.tsx
+++ b/src/library/ListItem/Labels/Select.tsx
@@ -5,7 +5,7 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faCheck, faCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { SelectSingleWrapper, SelectWrapper } from 'library/ListItem/Wrappers';
-import { useTheme } from 'styled-components';
+import { useTheme } from 'styled-components/macro';
 import { defaultThemes } from 'theme/default';
 import { useList } from '../../List/context';
 import { SelectProps } from '../types';

--- a/src/library/ListItem/Wrappers.ts
+++ b/src/library/ListItem/Wrappers.ts
@@ -3,7 +3,7 @@
 
 import { SmallFontSizeMaxWidth } from 'consts';
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   backgroundDropdown,
   backgroundModalItem,

--- a/src/library/Menu/Wrappers.ts
+++ b/src/library/Menu/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FloatingMenuWidth } from 'consts';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderPrimary, modalBackground, textSecondary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/library/Modal/Wrappers.tsx
+++ b/src/library/Modal/Wrappers.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderPrimary, textPrimary, textSecondary } from 'theme';
 
 export const TitleWrapper = styled.div<{ fixed: boolean }>`

--- a/src/library/NetworkBar/Wrappers.ts
+++ b/src/library/NetworkBar/Wrappers.ts
@@ -3,7 +3,7 @@
 
 import { SideMenuStickyThreshold } from 'consts';
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { backgroundNetworkBar, networkColor, textSecondary } from 'theme';
 
 export const Wrapper = styled(motion.div)`

--- a/src/library/Notifications/Wrapper.ts
+++ b/src/library/Notifications/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   backgroundError,
   backgroundSuccess,

--- a/src/library/OpenHelpIcon/Wrapper.tsx
+++ b/src/library/OpenHelpIcon/Wrapper.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   buttonHelpBackground,
   buttonPrimaryBackground,

--- a/src/library/Overlay/Wrappers.tsx
+++ b/src/library/Overlay/Wrappers.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   buttonPrimaryBackground,
   cardShadow,

--- a/src/library/PoolAccount/Wrapper.ts
+++ b/src/library/PoolAccount/Wrapper.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderSecondary, textSecondary } from 'theme';
 import { WrapperProps } from './types';
 

--- a/src/library/SetupSteps/Footer/Wrapper.ts
+++ b/src/library/SetupSteps/Footer/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Wrapper = styled.div`
   width: 100%;

--- a/src/library/SetupSteps/Header/Wrapper.ts
+++ b/src/library/SetupSteps/Header/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { networkColor, textSecondary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/library/SideMenu/Heading/Wrapper.tsx
+++ b/src/library/SideMenu/Heading/Wrapper.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { textSecondary } from 'theme';
 
 export const Wrapper = styled.div<{ minimised: number }>`

--- a/src/library/SideMenu/Primary/Wrappers.tsx
+++ b/src/library/SideMenu/Primary/Wrappers.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   highlightPrimary,
   highlightSecondary,

--- a/src/library/SideMenu/Secondary/Wrappers.tsx
+++ b/src/library/SideMenu/Secondary/Wrappers.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   borderPrimary,
   highlightPrimary,

--- a/src/library/SideMenu/Wrapper.ts
+++ b/src/library/SideMenu/Wrapper.ts
@@ -6,7 +6,7 @@ import {
   SideMenuMinimisedWidth,
   SideMenuStickyThreshold,
 } from 'consts';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   backgroundOverlay,
   borderPrimary,

--- a/src/library/Stat/Wrapper.ts
+++ b/src/library/Stat/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Wrapper = styled.div`
   padding: 0.15rem 0.25rem;

--- a/src/library/StatBoxList/Wrapper.ts
+++ b/src/library/StatBoxList/Wrapper.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import {
   backgroundSecondary,

--- a/src/library/StatusButton/Wrapper.ts
+++ b/src/library/StatusButton/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { buttonPrimaryBackground, textPrimary, textSecondary } from 'theme';
 
 export const Wrapper = styled.button`

--- a/src/library/StatusLabel/Wrapper.ts
+++ b/src/library/StatusLabel/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { backgroundLabel, textSecondary } from 'theme';
 import { WrapperProps } from './types';
 

--- a/src/library/SubscanButton/index.tsx
+++ b/src/library/SubscanButton/index.tsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useApi } from 'contexts/Api';
 import { useTheme } from 'contexts/Themes';
 import { useUi } from 'contexts/UI';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { defaultThemes, networkColors } from 'theme/default';
 import { WrapperProps } from './types';
 

--- a/src/library/Tips/Wrappers.ts
+++ b/src/library/Tips/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { helpButton, textPrimary, textSecondary } from 'theme';
 
 export const TipWrapper = styled(motion.div)`

--- a/src/library/Tooltip/Wrapper.ts
+++ b/src/library/Tooltip/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { textInvert, tooltipBackground } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/modals/AccountPoolRoles/Wrappers.ts
+++ b/src/modals/AccountPoolRoles/Wrappers.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   backgroundSecondary,
   backgroundToggle,

--- a/src/modals/Bio/Wrapper.ts
+++ b/src/modals/Bio/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { textPrimary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/modals/ChangePoolRoles/Wrapper.ts
+++ b/src/modals/ChangePoolRoles/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderPrimary, textSecondary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/modals/ConnectAccounts/ReadOnly/Wrapper.ts
+++ b/src/modals/ConnectAccounts/ReadOnly/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   borderPrimary,
   borderSecondary,

--- a/src/modals/ConnectAccounts/ReadOnlyInput/Wrapper.ts
+++ b/src/modals/ConnectAccounts/ReadOnlyInput/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderPrimary, textDanger, textSecondary, textSuccess } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/modals/ConnectAccounts/Wrappers.ts
+++ b/src/modals/ConnectAccounts/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   backgroundToggle,
   borderPrimary,

--- a/src/modals/JoinPool/Wrapper.ts
+++ b/src/modals/JoinPool/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const ContentWrapper = styled.div`
   width: 100%;

--- a/src/modals/LeavePool/Wrapper.ts
+++ b/src/modals/LeavePool/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const ContentWrapper = styled.div`
   width: 100%;

--- a/src/modals/ManagePool/Wrappers.ts
+++ b/src/modals/ManagePool/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { backgroundToggle, buttonPrimaryBackground, textPrimary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/modals/Networks/Wrapper.ts
+++ b/src/modals/Networks/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   backgroundToggle,
   borderPrimary,

--- a/src/modals/NominateFromFavorites/Wrappers.ts
+++ b/src/modals/NominateFromFavorites/Wrappers.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { networkColor, textSecondary } from 'theme';
 
 export const ListWrapper = styled.div`

--- a/src/modals/PoolNominations/Wrappers.ts
+++ b/src/modals/PoolNominations/Wrappers.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { networkColor, textSecondary } from 'theme';
 
 export const ListWrapper = styled.div`

--- a/src/modals/SelectFavorites/Wrappers.ts
+++ b/src/modals/SelectFavorites/Wrappers.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { networkColor, textSecondary } from 'theme';
 
 export const ListWrapper = styled.div`

--- a/src/modals/UnlockChunks/Wrappers.ts
+++ b/src/modals/UnlockChunks/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { buttonPrimaryBackground, textSecondary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/modals/UpdateBond/Wrappers.ts
+++ b/src/modals/UpdateBond/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { backgroundToggle, buttonPrimaryBackground, textPrimary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/modals/UpdateController/Wrapper.ts
+++ b/src/modals/UpdateController/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Wrapper = styled.div`
   display: flex;

--- a/src/modals/Wrappers.ts
+++ b/src/modals/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   borderPrimary,
   cardBorder,

--- a/src/pages/Community/Wrappers.ts
+++ b/src/pages/Community/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   backgroundDropdown,
   backgroundSecondary,

--- a/src/pages/Feedback/Wrappers.ts
+++ b/src/pages/Feedback/Wrappers.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { textSecondary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/pages/Nominate/Active/Controller/Wrapper.ts
+++ b/src/pages/Nominate/Active/Controller/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 interface WrapperProps {
   paddingLeft: boolean;

--- a/src/pages/Nominate/Active/Nominations/Wrapper.tsx
+++ b/src/pages/Nominate/Active/Nominations/Wrapper.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Wrapper = styled.div`
   flex: 1;

--- a/src/pages/Nominate/Setup/Payee/Wrappers.tsx
+++ b/src/pages/Nominate/Setup/Payee/Wrappers.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SectionFullWidthThreshold } from 'consts';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   borderPrimary,
   buttonPrimaryBackground,

--- a/src/pages/Nominate/Setup/Summary/Wrapper.tsx
+++ b/src/pages/Nominate/Setup/Summary/Wrapper.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderPrimary, networkColor, textSecondary } from 'theme';
 
 export const SummaryWrapper = styled.div`

--- a/src/pages/Nominate/Wrappers.tsx
+++ b/src/pages/Nominate/Wrappers.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { textSecondary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/pages/Overview/NetworkSats/Wrappers.ts
+++ b/src/pages/Overview/NetworkSats/Wrappers.ts
@@ -3,7 +3,7 @@
 
 import { SmallFontSizeMaxWidth } from 'consts';
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderPrimary, networkColor, textSecondary } from 'theme';
 
 export const Wrapper = styled.div`

--- a/src/pages/Overview/Tips/Wrappers.tsx
+++ b/src/pages/Overview/Tips/Wrappers.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   backgroundLabel,
   networkColor,

--- a/src/pages/Overview/Wrappers.ts
+++ b/src/pages/Overview/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { MediumFontSizeMaxWidth, SmallFontSizeMaxWidth } from 'consts';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   borderPrimary,
   borderSecondary,

--- a/src/pages/Payouts/Wrappers.ts
+++ b/src/pages/Payouts/Wrappers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   backgroundDropdown,
   borderPrimary,

--- a/src/pages/Pools/Create/Summary/Wrapper.ts
+++ b/src/pages/Pools/Create/Summary/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderPrimary, networkColor, textSecondary } from 'theme';
 
 export const SummaryWrapper = styled.div`

--- a/src/pages/Pools/Home/ManagePool/Wrappers.tsx
+++ b/src/pages/Pools/Home/ManagePool/Wrappers.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SectionFullWidthThreshold } from 'consts';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderPrimary } from 'theme';
 
 export const RolesWrapper = styled.div`

--- a/src/pages/Pools/Home/PoolStats/Wrappers.ts
+++ b/src/pages/Pools/Home/PoolStats/Wrappers.ts
@@ -3,7 +3,7 @@
 
 import { SmallFontSizeMaxWidth } from 'consts';
 import { motion } from 'framer-motion';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import {
   borderPrimary,
   networkColor,

--- a/src/pages/Pools/Home/Status/Membership/Wrapper.ts
+++ b/src/pages/Pools/Home/Status/Membership/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 interface WrapperProps {
   paddingLeft: boolean;

--- a/src/pages/Pools/PoolAccount/Wrapper.tsx
+++ b/src/pages/Pools/PoolAccount/Wrapper.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { textPrimary, textSecondary } from 'theme';
 
 export const Wrapper = styled.div<{ last?: boolean }>`

--- a/src/pages/Pools/Roles/RoleEditInput/Wrapper.ts
+++ b/src/pages/Pools/Roles/RoleEditInput/Wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { borderPrimary, textDanger, textSecondary, textSuccess } from 'theme';
 
 export const Wrapper = styled.div`


### PR DESCRIPTION
This is my small initiative to improve styled components debugging: the import change from `styled-components` to `styled-components/macro` turns on [enhanced debugging tools](https://styled-components.com/docs/tooling) *, which, among others, add readable component names to the otherwise inhuman class hashes:

_before -> after_
![image](https://user-images.githubusercontent.com/6209244/216205542-792367de-8b58-464d-8167-52786d526260.png)

I turned it on locally to make familiarizing with the repo easier; figured I'd make a PR since it's an overall very useful feature.

_Note: Fear not the number of changed files - almost all of them are the same, tiny change._

---

\* Normally we'd use a babel plugin for that and thus not have to update the import statements, but since CRA does not allow custom babel config, I had to fall back to using the macro.