### PR TITLE
A0-2307: Reset all app states upon network change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@
 import { DefaultNetwork } from 'consts';
 import { ThemesProvider } from 'contexts/Themes';
 import { i18next } from 'locale';
-import { Providers } from 'Providers';
+import Providers from 'Providers';
 import React from 'react';
 import { I18nextProvider } from 'react-i18next';
 

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -60,9 +60,8 @@ export const ThemedRouter = () => {
   );
 };
 
-export const Providers = withProviders(
+const AllProviders = withProviders(
   FiltersProvider,
-  APIProvider,
   ExtensionsProvider,
   ConnectProvider,
   HelpProvider,
@@ -89,4 +88,21 @@ export const Providers = withProviders(
   PayoutsCacheProvider
 )(ThemedRouter);
 
-export default Providers;
+const ProvidersWithNetwork = () => {
+  const { network } = useApi();
+
+  return (
+    <AllProviders
+      key={
+        /* We want all states of the app to be completely wiped during network changes. */
+        network.endpoints.rpc
+      }
+    />
+  );
+};
+
+export default () => (
+  <APIProvider>
+    <ProvidersWithNetwork />
+  </APIProvider>
+);

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -174,6 +174,8 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
     } else {
       _provider = new WsProvider(endpoints.rpc);
     }
+    provider?.disconnect(); // Disconnect the previous provider - no need to wait for it, can be done in the background
+
     setNetwork({
       name: _network,
       meta: NETWORKS[_network],


### PR DESCRIPTION
So the culprit of most (all?) problems with network changes was no states being reset during the change. And there are [plenty](https://github.com/Cardinal-Cryptography/aleph-zero-dashboard/blob/master/src/Providers.tsx#L64-L89) :P

Well, not all of them are related to networks, but many are, some are in a very obscure, indirect way - it'd be hard to find all the pieces that need to be reset, hard to reset them (due to a highly overcomplicated implementation - lots of unnecessary `useState`s with `useEffect`s that could've been just calculated values, lots of state values replicated in `ref`s) and even harder to test for regressions.

Taken that into account and the fact, that state leaked between the networks can be very dangerous (money loss) **I reckoned it's best to just reset all of them (remount the app)**. The bonus, important advantage is that if new state is added in the future, a dev doesn't have to know/remember to add it to the _reset list_, which would, again, be prone to money-loss-causing bugs.