### PR TITLE
A0-2896: Fix Kustomize variable

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -12,6 +12,9 @@ inputs:
       - testnet
       - mainnet
     required: true
+  kustomize_version:
+    required: false
+    default: "5.1.1"
 
 runs:
   using: composite
@@ -27,7 +30,7 @@ runs:
     - name: KUSTOMIZE | Init kustomize
       uses: imranismail/setup-kustomize@v2
       with:
-        kustomize-version: ${{ vars.KUSTOMIZE_VERSION }}
+        kustomize-version: ${{ inputs.kustomize_version }}
 
     - name: KUSTOMIZE | Update docker image tag
       shell: bash

--- a/.github/workflows/build-and-deploy-to-mainnet.yaml
+++ b/.github/workflows/build-and-deploy-to-mainnet.yaml
@@ -39,5 +39,6 @@ jobs:
         id: deploy_mainnet
         with:
           environment: mainnet
+          kustomize_version: ${{ vars.KUSTOMIZE_VERSION }}
           image_tag: ${{ needs.build_and_push.outputs.image_tag }}
           github_token: ${{ secrets.CI_GH_TOKEN }}

--- a/.github/workflows/build-and-deploy-to-testnet.yaml
+++ b/.github/workflows/build-and-deploy-to-testnet.yaml
@@ -45,5 +45,6 @@ jobs:
         id: deploy_testnet
         with:
           environment: testnet
+          kustomize_version: ${{ vars.KUSTOMIZE_VERSION }}
           image_tag: ${{ needs.build_and_push.outputs.image_tag }}
           github_token: ${{ secrets.CI_GH_TOKEN }}


### PR DESCRIPTION
Fixed variable in `deploy` action. The problem was that you cannot use `vars` inside actions. `Vars` are supposed to be used in workflows.
To fix that I changed `vars` inside `deploy` action to `input`. Then `input` gets its value from workflow in which I finally used `${{ vars.KUSTOMIZE_VERSION }}`.