### PR TITLE
A0-4125: [staking-dashboard] When unbonding, leaving pool or unbonding in pool, time to withdraw is incorrect

### DIFF
--- a/src/library/Hooks/useErasToTimeLeft/index.tsx
+++ b/src/library/Hooks/useErasToTimeLeft/index.tsx
@@ -7,7 +7,7 @@ import { useApi } from 'contexts/Api';
 
 export const useErasToTimeLeft = () => {
   const { consts } = useApi();
-  const { epochDuration, expectedBlockTime, sessionsPerEra } = consts;
+  const { expectedEraTime, expectedBlockTime } = consts;
 
   // converts a number of eras to timeleft in seconds.
   const erasToSeconds = (eras: BigNumber) => {
@@ -15,7 +15,7 @@ export const useErasToTimeLeft = () => {
       return 0;
     }
     // store the duration of an era in number of blocks.
-    const eraDurationBlocks = epochDuration.multipliedBy(sessionsPerEra);
+    const eraDurationBlocks = expectedEraTime.dividedBy(1000);
     // estimate the duration of the era in seconds.
     const eraDuration = eraDurationBlocks
       .multipliedBy(expectedBlockTime)


### PR DESCRIPTION
When 
* unbonding in staking, or
* leaving pool, or,
* unbonding in pool view
There’s incorrect label saying `Once unbonding, your funds to become available after 37 days, 9 hours.`

![image](https://github.com/Cardinal-Cryptography/aleph-zero-dashboard/assets/3909333/b2a8710e-86ea-4d95-81e7-ad8420690238)

Instead label should mention 14 days, a default unbound period on AlephNode chain, e.g.

![image](https://github.com/Cardinal-Cryptography/aleph-zero-dashboard/assets/3909333/d005c93b-88cd-42fc-b58e-12cc9c5f25d3)
