### PR TITLE
A0-2999: Run all workflows on node20

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: GIT | Checkout aleph-apps repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Cardinal-Cryptography/aleph-apps
         token: ${{ inputs.github_token }}

--- a/.github/workflows/automatic-upstream-merge-pr.yml
+++ b/.github/workflows/automatic-upstream-merge-pr.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Merge upstream repo
         uses: Cardinal-Cryptography/github-actions/test-upstream-merge@v3

--- a/.github/workflows/build-and-deploy-to-devnet.yaml
+++ b/.github/workflows/build-and-deploy-to-devnet.yaml
@@ -14,7 +14,7 @@ jobs:
       name: devnet
     steps:
       - name: GIT | Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build and push devnet image
         uses: ./.github/actions/build-and-push
@@ -35,7 +35,7 @@ jobs:
       name: devnet
     steps:
       - name: GIT | Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Deploy Aleph Zero Dashboard to Devnet
         uses: ./.github/actions/deploy

--- a/.github/workflows/build-and-deploy-to-mainnet.yaml
+++ b/.github/workflows/build-and-deploy-to-mainnet.yaml
@@ -11,7 +11,7 @@ jobs:
       name: mainnet
     steps:
       - name: GIT | Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: DOCKER | Build and push mainnet image
         uses: ./.github/actions/build-and-push
@@ -32,7 +32,7 @@ jobs:
       name: mainnet
     steps:
       - name: GIT | Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: MAINNET | Deploy Aleph Zero Dashboard
         uses: ./.github/actions/deploy

--- a/.github/workflows/build-and-deploy-to-testnet.yaml
+++ b/.github/workflows/build-and-deploy-to-testnet.yaml
@@ -11,7 +11,7 @@ jobs:
       name: testnet
     steps:
       - name: GIT | Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: DOCKER | Build and push testnet image
         uses: ./.github/actions/build-and-push
@@ -32,7 +32,7 @@ jobs:
       name: testnet
     steps:
       - name: GIT | Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: TESTNET | Deploy Aleph Zero Dashboard
         uses: ./.github/actions/deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: yarn install


### PR DESCRIPTION
See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ for more info.